### PR TITLE
[FIX] Remove unused parameter from function <recv_probe_response>

### DIFF
--- a/cs168-sp25-proj1-traceroute/traceroute.py
+++ b/cs168-sp25-proj1-traceroute/traceroute.py
@@ -108,7 +108,7 @@ def check_ttl_expired(icmp: ICMP):
 def check_port_unreachable(icmp: ICMP):
     return icmp.type == 3 and icmp.code == 3
 
-def recv_probe_response(recvsock: util.Socket, ttl: int):
+def recv_probe_response(recvsock: util.Socket):
     while recvsock.recv_select():
         packet, addr = recvsock.recvfrom()
         ipv4 = IPv4(packet)
@@ -156,7 +156,7 @@ def traceroute(sendsock: util.Socket, recvsock: util.Socket, ip: str) \
         routers = []
         for _ in range(PROBE_ATTEMPT_COUNT):
             sendsock.sendto(b"traceroute probe", (ip, TRACEROUTE_PORT_NUMBER))
-            addr = recv_probe_response(recvsock, ttl)
+            addr = recv_probe_response(recvsock)
             if addr is not None and addr not in routers:
                 routers.append(addr)
         util.print_result(routers, ttl)


### PR DESCRIPTION
The parameter <ttl> in <recv_probe_response> was not used anywhere. Removing it simplifies the function signature and clarifies usage.
<img width="1396" height="860" alt="image" src="https://github.com/user-attachments/assets/ee673bc9-da61-4d0e-8c40-94f268663654" />
